### PR TITLE
Fixed typo in sidenav

### DIFF
--- a/docs/klaytn-contracts/tools-and-sdks.md
+++ b/docs/klaytn-contracts/tools-and-sdks.md
@@ -1,6 +1,6 @@
 ---
 title: klaytn contracts
-sidebar_label: Tooks and SDK
+sidebar_label: Tools and SDKs
 ---
 
 # 💼 Tools and SDKs <a id="tools-and-sdks"></a>

--- a/i18n/ko/docusaurus-plugin-content-docs/current/klaytn-contracts/tools-and-sdks.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/klaytn-contracts/tools-and-sdks.md
@@ -1,6 +1,6 @@
 ---
 title: klaytn contracts
-sidebar_label: Tooks and SDK
+sidebar_label: Tools and SDKs
 ---
 
 # 💼 Tools and SDKs <a id="tools-and-sdks"></a>


### PR DESCRIPTION
## What it solves
Resolves #
Fixed typo in side nav for "Tools & Sdks".
