### PR TITLE
Chainlink removed

### DIFF
--- a/docs/decentralized-oracle/oracle-providers/overview.md
+++ b/docs/decentralized-oracle/oracle-providers/overview.md
@@ -9,7 +9,6 @@ Below is a list of decentralized oracles that Klaytn has integrated and that you
 
 * [Orakl Network](https://docs.orakl.network)
 * [Witnet](https://docs.witnet.io/)
-* [Chainlink](https://docs.chain.link/getting-started/conceptual-overview)
 * [SupraOracles](https://data.supraoracles.com/networks/klaytn)
 * [KlayOracle](https://www.klayoracle.com/)
 


### PR DESCRIPTION
## What it solves
Chainlink removed from list of Oracle providers on Klaytn
