### PR TITLE
Chainlink removed from list of Oracle providers

### DIFF
--- a/i18n/ko/docusaurus-plugin-content-docs/current/decentralized-oracle/oracle-providers/overview.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/decentralized-oracle/oracle-providers/overview.md
@@ -9,8 +9,9 @@ Below is a list of decentralized oracles that Klaytn has integrated and that you
 
 * [Orakl Network](https://docs.orakl.network)
 * [Witnet](https://docs.witnet.io/)
-* [Chainlink](https://docs.chain.link/getting-started/conceptual-overview)
 * [SupraOracles](https://docs.chain.link/getting-started/conceptual-overview)
+* [KlayOracle](https://www.klayoracle.com/)
+
 
 
 :::info


### PR DESCRIPTION
## What it solves
Chainlink removed from list of Oracle providers on Klaytn
