### PR TITLE
fix rpc-url hosted by klaytn foundation and delete retired node

### DIFF
--- a/docs/rpc-endpoint/overview.mdx
+++ b/docs/rpc-endpoint/overview.mdx
@@ -53,23 +53,11 @@ https://public-node-api.klaytnapi.com/v1/baobab
 ```js
 Mainnet 
 
-https://public-node-api.klaytnapi.com/v1/baobab
+https://public-en-cypress.klaytn.net
 
 Testnet
 
-https://api.baobab.klaytn.net:8651
-```
-
-</TabItem>
-<TabItem value="fantrie" label="Fantrie">
-
-```js
-
-Testnet
-
-https://baobab01.fautor.app/
-https://baobab02.fautor.app/
-
+https://public-en-baobab.klaytn.net
 ```
 
 </TabItem>
@@ -101,19 +89,7 @@ wss://public-en-cypress.klaytn.net/ws
 
 Testnet
 
-wss://api.baobab.klaytn.net:8652
-```
-
-</TabItem>
-<TabItem value="fantrie" label="Fantrie">
-
-```js
-
-Testnet
-
-wss://baobab01.fautor.app/ws/
-wss://baobab02.fautor.app/ws/
-
+wss://public-en-baobab.klaytn.net/ws
 ```
 
 </TabItem>
@@ -155,7 +131,7 @@ In order to develop a reputation system in your metaverse application, for insta
 
 
 ### Provider
-**A. Klaytn Foundation**
+**Klaytn Foundation**
 
 <Tabs>
 <TabItem value="kf1" label="HTTPS">
@@ -187,41 +163,6 @@ wss://archive-en.baobab.klaytn.net/ws
 </TabItem>
 
 </Tabs>
-
-
-**B. Fantrie**
-
-<Tabs>
-<TabItem value="fantrie" label="HTTPS">
-
-```js
-Mainnet
-
-https://cypress.fautor.app/archive
-
-Testnet
-
-https://baobab.fautor.app/archive
-```
-
-</TabItem>
-
-<TabItem value="fantrie1" label="WSS">
-
-```js
-Mainnet
-
-wss://cypress.fautor.app/archive/ws
-
-Testnet
-
-wss://baobab.fautor.app/archive/ws
-```
-
-</TabItem>
-
-</Tabs>
-
 
 ## How to run your own Node
 In general public RPC endpoints will have rate limits due to security reasons or the subscription plan might be expensive depending on the service providers. In such case you can opt to run your own node to interact with Klaytn network. 


### PR DESCRIPTION
## What it solves
Resolved #

## How this PR fixes it
Updated rpc-url hosted by klaytn foundation and delete retired node (fantrie)

## How to test it
I've tested the newly updated rpc-urls

## Analytics changes

## Screenshots
